### PR TITLE
fix(auth): prevent storing incomplete Google users in DB 

### DIFF
--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -72,12 +72,14 @@ export class AuthController {
     res.json({ message: 'Sign out successful' });
   }
 
+  @Public()
   @Get('google/login')
   @UseGuards(GoogleAuthGuard)
   handleGoogleLogin() {
     return { msg: 'Google Authentication' };
   }
 
+  @Public()
   @Get('google/callback')
   @UseGuards(GoogleAuthGuard)
   async handleGoogleRedirect(@Req() req, @Res() res: Response) {


### PR DESCRIPTION
Updated validateGoogleUser to prevent storing incomplete users in the database.

Throws HttpException with status 428 PRECONDITION_REQUIRED for users who need to complete their information.

Improved error handling by providing clear messages for incomplete user registration.

Closes #21