### PR TITLE
feat(auth): add authMethod field with default email/password

### DIFF
--- a/prisma/migrations/20250419232333_add_auth_method_enum/migration.sql
+++ b/prisma/migrations/20250419232333_add_auth_method_enum/migration.sql
@@ -1,0 +1,5 @@
+-- CreateEnum
+CREATE TYPE "AuthMethod" AS ENUM ('EMAIL_PASSWORD', 'OAUTH_GOOGLE');
+
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN     "authMethod" "AuthMethod" NOT NULL DEFAULT 'EMAIL_PASSWORD';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -17,6 +17,7 @@ model User {
   password      String?
   name          String?
   photoPath    String?           @default("")
+  authMethod    AuthMethod        @default(EMAIL_PASSWORD) 
   createdAt     DateTime          @default(now())
   lastLoginAt   DateTime?
   isActive      Boolean           @default(true)
@@ -57,6 +58,11 @@ model Student {
   user           User           @relation("StudentUser", fields: [userId], references: [id])
   approvalUpdatedByUserId Int?
   approvalUpdatedByUser   User?      @relation("ApprovalUpdatedByUser", fields: [approvalUpdatedByUserId], references: [id], onDelete: SetNull)
+}
+
+enum AuthMethod {
+  EMAIL_PASSWORD
+  OAUTH_GOOGLE
 }
 
 enum UserRole {

--- a/src/admins/dto/create-admin.dto.ts
+++ b/src/admins/dto/create-admin.dto.ts
@@ -1,6 +1,6 @@
 import { SignupAuthDto } from "@/auth/dto/signup-auth.dto";
 import { UserRole } from "@prisma/client";
-import { IsEnum, IsOptional } from "class-validator";
+import { IsEnum, IsOptional, IsString, Matches, MinLength } from "class-validator";
 import { ApiProperty } from "@nestjs/swagger";
 
 export class AdminSignupDto extends SignupAuthDto {
@@ -13,5 +13,18 @@ export class AdminSignupDto extends SignupAuthDto {
     @IsEnum(UserRole)
     @IsOptional()
     role?: UserRole = UserRole.ADMIN;
+
+    // Override to make password ALWAYS required for admin creation
+    @ApiProperty({
+        description: 'Password (must contain uppercase, lowercase, number and special character)',
+        example: 'AdminPass123!',
+        minLength: 8
+    })
+    @IsString()
+    @MinLength(8)
+    @Matches(/^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[@$!%*?&])[A-Za-z\d@$!%*?&]{8,}$/, {
+        message: 'Password must contain at least 1 uppercase, 1 lowercase, 1 number and 1 special character',
+    })
+    password: string;
   }
   

--- a/src/auth/__http_tests__/auth.signup.http
+++ b/src/auth/__http_tests__/auth.signup.http
@@ -1,9 +1,9 @@
 @port = {{$dotenv API_PORT}}
 @baseUrl = http://localhost:{{port}}
-@email = test1ss6@example.com
+@email = test1ss3@example.com
 @password = Test123!@$
-@username = eestsuser16s
-@name = Test User 14
+@username = test_user3
+@name = Test User
 
 ### Sign Up - Valid Input
 POST {{baseUrl}}/auth/signup
@@ -12,9 +12,8 @@ Content-Type: application/json
 {
     "email": "{{email}}",
     "username": "{{username}}",
-    "password": "{{password}}",
     "name": "{{name}}",
-    "academicNumber": "1299567589123",
+    "academicNumber": "1299567589126",
     "department": "IT",
     "studyLevel": 2
 }

--- a/src/auth/decorators/swagger.decorators.ts
+++ b/src/auth/decorators/swagger.decorators.ts
@@ -19,7 +19,7 @@ export function SwaggerAuth() {
 export function SwaggerSignup() {
   return applyDecorators(
     ApiOperation({ summary: 'Register a new student user' }),
-    ApiBody({ type: StudentSignUpDto }),
+    ApiBody({ type: StudentSignUpDto,  description: 'User registration data. Password is required only for EMAIL_PASSWORD auth method.'}),
     ApiResponse({
       status: 201,
       description: 'User registered successfully',

--- a/src/auth/dto/signup-auth.dto.ts
+++ b/src/auth/dto/signup-auth.dto.ts
@@ -1,10 +1,13 @@
-import { Department } from '@prisma/client';
+import { Department, AuthMethod } from '@prisma/client';
 import {
   IsEmail,
   IsString,
   MinLength,
   Matches,
   MaxLength,
+  IsEnum,
+  ValidateIf,
+  IsOptional,
 } from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
 
@@ -45,14 +48,22 @@ export class SignupAuthDto {
   name: string;
 
   @ApiProperty({
-    description: 'Password (must contain uppercase, lowercase, number and special character)',
-    example: 'Password123!',
-    minLength: 8,
-    maxLength: 72,
+    description: 'Auth method (omit for email/password)',
+    enum: AuthMethod,
+    required: false,
+    default: AuthMethod.EMAIL_PASSWORD
   })
+  @IsEnum(AuthMethod)
+  @IsOptional()
+  authMethod?: AuthMethod;
+
+@ApiProperty({
+    description: 'Password (required if authMethod is EMAIL_PASSWORD or undefined)',
+    required: false
+  })
+  @ValidateIf(o => !o.authMethod || o.authMethod === AuthMethod.EMAIL_PASSWORD)
   @IsString()
   @MinLength(8)
-  @MaxLength(72)
   @Matches(
     /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[@$!%*?&])[A-Za-z\d@$!%*?&]{8,}$/,
     {
@@ -60,5 +71,5 @@ export class SignupAuthDto {
         'Password must contain at least 1 uppercase letter, 1 lowercase letter, 1 number and 1 special character',
     },
   )
-  password: string;
+  password?: string;
 }


### PR DESCRIPTION
- Added AuthMethod enum to User model (EMAIL_PASSWORD|OAUTH_GOOGLE)
- Defaults to EMAIL_PASSWORD when not specified
- Updated signup flow to:
  * Treat missing authMethod as EMAIL_PASSWORD
  * Only require password for EMAIL_PASSWORD auth
  * Automatically set OAUTH_GOOGLE for Google signups
- Modified SignupAuthDto to:
  * Make both authMethod and password optional
  * Validate password only when authMethod is EMAIL_PASSWORD or undefined
- Added database migration with EMAIL_PASSWORD as default value
- Updated Swagger docs to reflect optional fields and default behavior