### PR TITLE
fix(auth): prevent unauthorized emails during `EMAIL_PASSWORD` signup and improve signin flow

### DIFF
--- a/src/admins/admins.service.ts
+++ b/src/admins/admins.service.ts
@@ -96,7 +96,7 @@ export class AdminsService implements OnModuleInit {
     async createAdmin(input: AdminSignupDto) {
         const { email, name, username, password } = input;
 
-        const existingUser = await this.usersService.findUserByEmailOrUsername(email, username);
+        const existingUser = await this.usersService.findUserByEmailOrUsername(email || '', username);
         if (existingUser) {
             throw new BadRequestException('Admin with this email or username already exists');
         }

--- a/src/auth/__http_tests__/auth.signin.http
+++ b/src/auth/__http_tests__/auth.signin.http
@@ -1,33 +1,25 @@
 @port = {{$dotenv API_PORT}}
 @baseUrl = http://localhost:{{port}}
-@email = test15@example.com
-@password = Test123!@#
-@adminEmail = {{$dotenv SUPER_ADMIN_EMAIL}}
+@username = test_user_new_
+@password = Test$1234
+@academicNumber = 1299569589195
+@adminUsername = {{$dotenv SUPER_ADMIN_USERNAME}}
 @adminPassword = {{$dotenv SUPER_ADMIN_PASSWORD}}
 
-### Sign In - Valid Credentials
+### Sign In - Student with Username
 POST {{baseUrl}}/auth/signin
 Content-Type: application/json
 
 {
-    "email": "{{adminEmail}}",
-    "password": "{{adminPassword}}"
-}
-
-### Sign In - Invalid Password
-POST {{baseUrl}}/auth/signin
-Content-Type: application/json
-
-{
-    "email": "{{email}}",
-    "password": "Test123!@#"
-}
-
-### Sign In - Non-existent User
-POST {{baseUrl}}/auth/signin
-Content-Type: application/json
-
-{
-    "email": "nonexistent@example.com",
+    "identifier": "{{username}}",
     "password": "{{password}}"
+}
+
+### Sign In - Admin with Username
+POST {{baseUrl}}/auth/signin
+Content-Type: application/json
+
+{
+    "identifier": "{{adminUsername}}",
+    "password": "{{adminPassword}}"
 }

--- a/src/auth/__http_tests__/auth.signup.http
+++ b/src/auth/__http_tests__/auth.signup.http
@@ -1,31 +1,19 @@
 @port = {{$dotenv API_PORT}}
 @baseUrl = http://localhost:{{port}}
-@email = test1ss3@example.com
-@password = Test123!@$
-@username = test_user3
-@name = Test User
+@username = test_user_new_3
+@password = Test$1234
+@academicNumber = 1299569589193
+@name = Test User 3
 
-### Sign Up - Valid Input
+### Sign Up - Valid Student Input (EMAIL_PASSWORD)
 POST {{baseUrl}}/auth/signup
 Content-Type: application/json
 
 {
-    "email": "{{email}}",
     "username": "{{username}}",
+    "password": "{{password}}",
     "name": "{{name}}",
-    "academicNumber": "1299567589126",
+    "academicNumber": "{{academicNumber}}",
     "department": "IT",
     "studyLevel": 2
-}
-
-
-### Sign Up - Existing User (Should Fail)
-POST {{baseUrl}}/auth/signup
-Content-Type: application/json
-
-{
-    "email": "{{email}}",
-    "username": "testuser2",
-    "password": "{{password}}",
-    "name": "Test User 2"
 }

--- a/src/auth/dto/signin-auth.dto.ts
+++ b/src/auth/dto/signin-auth.dto.ts
@@ -1,13 +1,13 @@
-import { IsEmail, IsString, MinLength } from 'class-validator';
+import { IsString, MinLength } from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
 
 export class SigninAuthDto {
   @ApiProperty({
-    description: 'User email address',
-    example: 'user@example.com',
+    description: 'Username or academic number for authentication',
+    example: 'username or 1234567890123',
   })
-  @IsEmail()
-  email: string;
+  @IsString()
+  identifier: string;
 
   @ApiProperty({
     description: 'User password',

--- a/src/auth/dto/signup-auth.dto.ts
+++ b/src/auth/dto/signup-auth.dto.ts
@@ -13,13 +13,16 @@ import { ApiProperty } from '@nestjs/swagger';
 
 export class SignupAuthDto {
   @ApiProperty({
-    description: 'User email address',
+    description: 'Email address (only required for Google OAuth)',
     example: 'user@example.com',
+    required: false,
     maxLength: 255,
   })
-  @IsEmail()
-  @MaxLength(255)
-  email: string;
+  @IsOptional()
+  @ValidateIf((o) => o.authMethod === AuthMethod.OAUTH_GOOGLE)
+  @IsEmail({}, { message: 'Please provide a valid email address' })
+  @MaxLength(255, { message: 'Email must not exceed 255 characters' })
+  email?: string;
 
   @ApiProperty({
     description: 'Username (letters, numbers, underscores and hyphens only)',
@@ -57,7 +60,7 @@ export class SignupAuthDto {
   @IsOptional()
   authMethod?: AuthMethod;
 
-@ApiProperty({
+  @ApiProperty({
     description: 'Password (required if authMethod is EMAIL_PASSWORD or undefined)',
     required: false
   })


### PR DESCRIPTION
- Disallowed user-provided email during signup if authMethod is EMAIL_PASSWORD
- Restricted email acceptance to OAUTH_GOOGLE only
- Updated signin to use only username or academic number with password
- Exposed `authMethod` in GET /users/me and `email` only if email exists

CLOSES #124 