### PR TITLE
refactor(api): streamline Auth/Role guards and TransformInterceptor

### DIFF
--- a/src/auth/guards/jwt-auth.guard.ts
+++ b/src/auth/guards/jwt-auth.guard.ts
@@ -27,15 +27,8 @@ export class JwtAuthGuard extends AuthGuard('jwt') {
   }
 
   handleRequest(err: Error | null, user: User): any {
-    if (err) {
-      throw new UnauthorizedException(
-        'Authentication error. Please try again.',
-      );
-    }
-    if (!user) {
-      throw new ForbiddenException(
-        'Access denied. Valid authentication required.',
-      );
+    if (err || !user) {
+      throw new UnauthorizedException('Authentication required');
     }
     return user;
   }

--- a/src/auth/guards/role-auth.guard.ts
+++ b/src/auth/guards/role-auth.guard.ts
@@ -37,14 +37,6 @@ export class RolesGuard implements CanActivate {
     const request = context.switchToHttp().getRequest();
     const user = request.user;
 
-    // If user is not signed in, don't allow access
-    if (!user) {
-      throw new UnauthorizedException('Access denied. Please log in.');
-    }
-
-    console.log('user ', user);
-    console.log('requiredRoles ', requiredRoles);
-
     return requiredRoles.includes(user.role);
   }
 }


### PR DESCRIPTION
- Remove redundant URL checks, imports and logs from JwtAuthGuard
- Replace ForbiddenException with UnauthorizedException in JwtAuthGuard’s handleRequest
- Consolidate @Public() handling and rely on Passport’s UnauthorizedException
- Simplify RolesGuard metadata lookup and default to empty roles array
- Update TransformInterceptor to wrap responses in '{ message, data [, meta] }' without statusCode